### PR TITLE
Use vLLM for completion and OpenAI for embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ Then you can connect to the database (password: `postgres`) and inspect or alter
 psql -U postgres -h localhost -p 5432
 
 \l
-\c postgres
+\c vector_store
 \dt
 
 select count(*) from vector_store;
 
 delete from vector_store;
 ```
+
+You can connect to the pgAdmin on http://localhost:5050  as user: `pgadmin4@pgadmin.org` and pass: `admin`.
+Then navigate to the `Databases/vector_store/Schemas/public/Tables/vector_store`.
 
 The UI tool [DBeaver](https://dbeaver.io/download/) is also a useful GUI for postgres.
 
@@ -67,7 +70,7 @@ The first thing you should do is load the data.  The examples show usage with th
 
 ### Loading, counting and deleting data
 
-```shell 
+```shell
 http POST http://localhost:8080/data/load
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,26 @@ services:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_PASSWORD=postgres
+          - POSTGRES_DB=vector_store
+          - PGPASSWORD=postgres
         logging:
           options:
             max-size: 10m
             max-file: "3"
         ports:
           - '5432:5432'
+        healthcheck:
+          test: "pg_isready -U postgres -d vector_store"
+          interval: 2s
+          timeout: 20s
+          retries: 10
+    pgadmin:
+        container_name: pgadmin_container
+        image: dpage/pgadmin4
+        environment:
+          PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
+          PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+        volumes:
+          - ./servers.json:/pgadmin4/servers.json
+        ports:
+          - "${PGADMIN_PORT:-5050}:80"

--- a/servers.json
+++ b/servers.json
@@ -1,0 +1,20 @@
+{
+	"Servers": {
+	  "1": {
+		"Name": "vector_store",
+		"Group": "Servers",
+		"Host": "postgres",
+		"Port": 5432,
+		"MaintenanceDB": "vector_store",
+		"Username": "postgres",
+		"SSLMode": "prefer",
+		"SSLCert": "<STORAGE_DIR>/.postgresql/postgresql.crt",
+		"SSLKey": "<STORAGE_DIR>/.postgresql/postgresql.key",
+		"SSLCompression": 0,
+		"Timeout": 10,
+		"UseSSHTunnel": 0,
+		"TunnelPort": "22",
+		"TunnelAuthentication": 0
+	  }
+	}
+  }

--- a/src/main/java/com/example/carina/config/VllmOpenAiApi.java
+++ b/src/main/java/com/example/carina/config/VllmOpenAiApi.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.carina.config;
+
+
+import java.time.LocalDate;
+
+import com.theokanning.openai.DeleteResult;
+import com.theokanning.openai.OpenAiResponse;
+import com.theokanning.openai.audio.TranscriptionResult;
+import com.theokanning.openai.audio.TranslationResult;
+import com.theokanning.openai.billing.BillingUsage;
+import com.theokanning.openai.billing.Subscription;
+import com.theokanning.openai.client.OpenAiApi;
+import com.theokanning.openai.completion.CompletionRequest;
+import com.theokanning.openai.completion.CompletionResult;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionResult;
+import com.theokanning.openai.edit.EditRequest;
+import com.theokanning.openai.edit.EditResult;
+import com.theokanning.openai.embedding.EmbeddingRequest;
+import com.theokanning.openai.embedding.EmbeddingResult;
+import com.theokanning.openai.engine.Engine;
+import com.theokanning.openai.file.File;
+import com.theokanning.openai.fine_tuning.FineTuningEvent;
+import com.theokanning.openai.fine_tuning.FineTuningJob;
+import com.theokanning.openai.fine_tuning.FineTuningJobRequest;
+import com.theokanning.openai.finetune.FineTuneEvent;
+import com.theokanning.openai.finetune.FineTuneRequest;
+import com.theokanning.openai.finetune.FineTuneResult;
+import com.theokanning.openai.image.CreateImageRequest;
+import com.theokanning.openai.image.ImageResult;
+import com.theokanning.openai.model.Model;
+import com.theokanning.openai.moderation.ModerationRequest;
+import com.theokanning.openai.moderation.ModerationResult;
+import io.reactivex.Single;
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.Multipart;
+import retrofit2.http.POST;
+import retrofit2.http.Part;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+import retrofit2.http.Streaming;
+
+/**
+ *
+ * @author Christian Tzolov
+ */
+public interface VllmOpenAiApi extends OpenAiApi {
+
+    @GET("v1/models")
+    Single<OpenAiResponse<Model>> listModels();
+
+    @GET("/api/v1/models/{model_id}")
+    Single<Model> getModel(@Path("model_id") String modelId);
+
+    @POST("/api/v1/completions")
+    Single<CompletionResult> createCompletion(@Body CompletionRequest request);
+
+    @Streaming
+    @POST("/api/v1/completions")
+    Call<ResponseBody> createCompletionStream(@Body CompletionRequest request);
+
+    @POST("/api/v1/chat/completions")
+    Single<ChatCompletionResult> createChatCompletion(@Body ChatCompletionRequest request);
+
+    @Streaming
+    @POST("/api/v1/chat/completions")
+    Call<ResponseBody> createChatCompletionStream(@Body ChatCompletionRequest request);
+
+    @Deprecated
+    @POST("/api/v1/engines/{engine_id}/completions")
+    Single<CompletionResult> createCompletion(@Path("engine_id") String engineId, @Body CompletionRequest request);
+
+    @POST("/api/v1/edits")
+    Single<EditResult> createEdit(@Body EditRequest request);
+
+    @Deprecated
+    @POST("/api/v1/engines/{engine_id}/edits")
+    Single<EditResult> createEdit(@Path("engine_id") String engineId, @Body EditRequest request);
+
+    @POST("/api/v1/embeddings")
+    Single<EmbeddingResult> createEmbeddings(@Body EmbeddingRequest request);
+
+    @Deprecated
+    @POST("/api/v1/engines/{engine_id}/embeddings")
+    Single<EmbeddingResult> createEmbeddings(@Path("engine_id") String engineId, @Body EmbeddingRequest request);
+
+    @GET("/api/v1/files")
+    Single<OpenAiResponse<File>> listFiles();
+
+    @Multipart
+    @POST("/api/v1/files")
+    Single<File> uploadFile(@Part("purpose") RequestBody purpose, @Part MultipartBody.Part file);
+
+    @DELETE("/api/v1/files/{file_id}")
+    Single<DeleteResult> deleteFile(@Path("file_id") String fileId);
+
+    @GET("/api/v1/files/{file_id}")
+    Single<File> retrieveFile(@Path("file_id") String fileId);
+
+    @POST("/api/v1/fine_tuning/jobs")
+    Single<FineTuningJob> createFineTuningJob(@Body FineTuningJobRequest request);
+
+    @GET("/api/v1/fine_tuning/jobs")
+    Single<OpenAiResponse<FineTuningJob>> listFineTuningJobs();
+
+    @GET("/api/v1/fine_tuning/jobs/{fine_tuning_job_id}")
+    Single<FineTuningJob> retrieveFineTuningJob(@Path("fine_tuning_job_id") String fineTuningJobId);
+
+    @POST("/api/v1/fine_tuning/jobs/{fine_tuning_job_id}/cancel")
+    Single<FineTuningJob> cancelFineTuningJob(@Path("fine_tuning_job_id") String fineTuningJobId);
+
+    @GET("/api/v1/fine_tuning/jobs/{fine_tuning_job_id}/events")
+    Single<OpenAiResponse<FineTuningEvent>> listFineTuningJobEvents(@Path("fine_tuning_job_id") String fineTuningJobId);
+
+    @Deprecated
+    @POST("/api/v1/fine-tunes")
+    Single<FineTuneResult> createFineTune(@Body FineTuneRequest request);
+
+    @POST("/api/v1/completions")
+    Single<CompletionResult> createFineTuneCompletion(@Body CompletionRequest request);
+
+    @Deprecated
+    @GET("/api/v1/fine-tunes")
+    Single<OpenAiResponse<FineTuneResult>> listFineTunes();
+
+    @Deprecated
+    @GET("/api/v1/fine-tunes/{fine_tune_id}")
+    Single<FineTuneResult> retrieveFineTune(@Path("fine_tune_id") String fineTuneId);
+
+    @Deprecated
+    @POST("/api/v1/fine-tunes/{fine_tune_id}/cancel")
+    Single<FineTuneResult> cancelFineTune(@Path("fine_tune_id") String fineTuneId);
+
+    @Deprecated
+    @GET("/api/v1/fine-tunes/{fine_tune_id}/events")
+    Single<OpenAiResponse<FineTuneEvent>> listFineTuneEvents(@Path("fine_tune_id") String fineTuneId);
+
+    @DELETE("/api/v1/models/{fine_tune_id}")
+    Single<DeleteResult> deleteFineTune(@Path("fine_tune_id") String fineTuneId);
+
+    @POST("/api/v1/images/generations")
+    Single<ImageResult> createImage(@Body CreateImageRequest request);
+
+    @POST("/api/v1/images/edits")
+    Single<ImageResult> createImageEdit(@Body RequestBody requestBody);
+
+    @POST("/api/v1/images/variations")
+    Single<ImageResult> createImageVariation(@Body RequestBody requestBody);
+
+    @POST("/api/v1/audio/transcriptions")
+    Single<TranscriptionResult> createTranscription(@Body RequestBody requestBody);
+
+    @POST("/api/v1/audio/translations")
+    Single<TranslationResult> createTranslation(@Body RequestBody requestBody);
+
+    @POST("/api/v1/moderations")
+    Single<ModerationResult> createModeration(@Body ModerationRequest request);
+
+    @Deprecated
+    @GET("/api/v1/engines")
+    Single<OpenAiResponse<Engine>> getEngines();
+
+    @Deprecated
+    @GET("/api/v1/engines/{engine_id}")
+    Single<Engine> getEngine(@Path("engine_id") String engineId);
+
+    /**
+     * Account information inquiry: It contains total amount (in US dollars) and other information.
+     *
+     * @return
+     */
+    @Deprecated
+    @GET("v1/dashboard/billing/subscription")
+    Single<Subscription> subscription();
+
+    /**
+     * Account call interface consumption amount inquiry.
+     * totalUsage = Total amount used by the account (in US cents).
+     *
+     * @param starDate
+     * @param endDate
+     * @return Consumption amount information.
+     */
+    @Deprecated
+    @GET("v1/dashboard/billing/usage")
+    Single<BillingUsage> billingUsage(@Query("start_date") LocalDate starDate, @Query("end_date") LocalDate endDate);
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,19 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://localhost:5432/vector_store
     username: postgres
     password: postgres
   ai:
     openai:
       # for chatgpt openai the base-url is known.  For models that expose an api compatible with chatgpt openai, specify the base-url
       #      base-url:
-      api-key: ${OPENAI_API_KEY}
       temperature: 0.3
-      model: gpt-3.5-turbo
+      # api-key: ${OPENAI_API_KEY}
+      # model: gpt-3.5-turbo
+      base-url: https://vllm.libra.decc.vmware.com/api/v1/
+      api-key: ${VLLM_DECC_API_KEY}
+      model: meta-llama/Llama-2-13b-chat-hf
 
+      embedding-base-url: https://api.openai.com
+      embedding-api-key: ${OPENAI_API_KEY}
+      embedding-model: text-embedding-ada-002


### PR DESCRIPTION
 - Extend the application.yml with separate configurations for the embedding and the completion (e.g. main) APIs.
 - Add VllmOpenAiApi.java and override the openAiClient bean configuration as a work-around the vLLM's /api path segment non-conformance.
 - Extend the docker-compose with pgAdmin accessible at localhost:5050
 - Change the Postgres vector_sotore database from "postgres" to "vector_store".
 - Reduce the vectorStoreRetriever's K from 5 to 4 as the vLLM token size of 4096 can lead to max_token issues.